### PR TITLE
Resolving cyclic references during Deep mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+*.iml

--- a/src/main/java/com/tw/examples/appender/masks/Deep.java
+++ b/src/main/java/com/tw/examples/appender/masks/Deep.java
@@ -3,6 +3,7 @@ package com.tw.examples.appender.masks;
 import com.google.common.base.Objects;
 import com.google.common.primitives.Primitives;
 import com.tw.examples.appender.masks.annotations.DeepMask;
+import com.tw.examples.appender.masks.annotations.IgnoreInLog;
 import com.tw.examples.appender.masks.annotations.Masked;
 
 import java.lang.reflect.Field;
@@ -51,7 +52,9 @@ public class Deep extends AbstractMask {
         Field[] declaredFields = object.getClass().getDeclaredFields();
         for (Field field : declaredFields) {
             try {
-                helper.add(field.getName(), getValue(field, object));
+                if(!field.isAnnotationPresent(IgnoreInLog.class)) {
+                    helper.add(field.getName(), getValue(field, object));
+                }
             } catch (ReflectiveOperationException e) {}
         }
 

--- a/src/main/java/com/tw/examples/appender/masks/Deep.java
+++ b/src/main/java/com/tw/examples/appender/masks/Deep.java
@@ -32,12 +32,12 @@ public class Deep extends AbstractMask {
 
     private String valueOf(Object object) {
         // if the object has already been masked, don't mask it again
-        if(maskedObjectsMap.contains(object.hashCode())) {
+        if(maskedObjectsMap.contains(object)) {
             return "";
         }
 
         if(isUserDefinedObject(object.getClass())) {
-            maskedObjectsMap.add(object.hashCode());
+            maskedObjectsMap.add(object);
         }
 
         return object.getClass().isAnnotationPresent(DeepMask.class)

--- a/src/main/java/com/tw/examples/appender/masks/Deep.java
+++ b/src/main/java/com/tw/examples/appender/masks/Deep.java
@@ -1,14 +1,20 @@
 package com.tw.examples.appender.masks;
 
 import com.google.common.base.Objects;
+import com.google.common.primitives.Primitives;
 import com.tw.examples.appender.masks.annotations.DeepMask;
 import com.tw.examples.appender.masks.annotations.Masked;
 
 import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Deep extends AbstractMask {
+    private Set<Object> maskedObjectsMap;
+
     public Deep(Object object) {
         super(object);
+        maskedObjectsMap = new HashSet<>();
     }
 
     // Required by @Masked annotation processor
@@ -18,10 +24,22 @@ public class Deep extends AbstractMask {
 
     @Override
     public String value() {
+        // clearing the entries for a fresh cycle
+        maskedObjectsMap.clear();
+
         return valueOf(object);
     }
 
     private String valueOf(Object object) {
+        // if the object has already been masked, don't mask it again
+        if(maskedObjectsMap.contains(object.hashCode())) {
+            return "";
+        }
+
+        if(isUserDefinedObject(object.getClass())) {
+            maskedObjectsMap.add(object.hashCode());
+        }
+
         return object.getClass().isAnnotationPresent(DeepMask.class)
                 ? introspect(object)
                 : object.toString();
@@ -55,5 +73,9 @@ public class Deep extends AbstractMask {
         String[] args = masked.args();
         AbstractMask mask = masked.type().getConstructor(Object.class, String[].class).newInstance(value, args);
         return mask.value();
+    }
+
+    private boolean isUserDefinedObject(Class clazz) {
+        return (!clazz.isPrimitive() && !clazz.equals(String.class) && !Primitives.isWrapperType(clazz));
     }
 }

--- a/src/main/java/com/tw/examples/appender/masks/annotations/IgnoreInLog.java
+++ b/src/main/java/com/tw/examples/appender/masks/annotations/IgnoreInLog.java
@@ -1,0 +1,11 @@
+package com.tw.examples.appender.masks.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface IgnoreInLog {
+}

--- a/src/test/java/com/tw/examples/appender/masks/DeepTest.java
+++ b/src/test/java/com/tw/examples/appender/masks/DeepTest.java
@@ -1,10 +1,12 @@
 package com.tw.examples.appender.masks;
 
 import com.tw.examples.appender.masks.objects.*;
+import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
+import org.mockito.internal.util.Primitives;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,6 +27,18 @@ public class DeepTest {
     public void shouldReturnMaskedValue(Object[] data) {
         Deep mask = new Deep(data[0]);
         assertThat(mask.value(), is(data[1]));
+    }
+
+    @Test
+    public void shouldNotLoopInfinitelyForCyclicReferences() {
+        CyclicReferenceObject1 cyclicReferenceObject1 = new CyclicReferenceObject1();
+        CyclicReferenceObject2 cyclicReferenceObject2 = new CyclicReferenceObject2();
+
+        cyclicReferenceObject1.cyclicReferenceObject2 = cyclicReferenceObject2;
+        cyclicReferenceObject2.cyclicReferenceObject1 = cyclicReferenceObject1;
+
+        Deep mask = new Deep(cyclicReferenceObject1);
+        assertThat(mask.value(), is("CyclicReferenceObject1{intValue=1, strValue=*oo!, cyclicReferenceObject2=CyclicReferenceObject2{intValue=1, strValue=*oo!, cyclicReferenceObject1=}}"));
     }
 }
 

--- a/src/test/java/com/tw/examples/appender/masks/DeepTest.java
+++ b/src/test/java/com/tw/examples/appender/masks/DeepTest.java
@@ -33,12 +33,23 @@ public class DeepTest {
     public void shouldNotLoopInfinitelyForCyclicReferences() {
         CyclicReferenceObject1 cyclicReferenceObject1 = new CyclicReferenceObject1();
         CyclicReferenceObject2 cyclicReferenceObject2 = new CyclicReferenceObject2();
-
         cyclicReferenceObject1.cyclicReferenceObject2 = cyclicReferenceObject2;
         cyclicReferenceObject2.cyclicReferenceObject1 = cyclicReferenceObject1;
+        String expectedMaskedValue = "CyclicReferenceObject1{intValue=1, strValue=*oo!, cyclicReferenceObject2=CyclicReferenceObject2{intValue=1, strValue=*oo!, cyclicReferenceObject1=}}";
 
         Deep mask = new Deep(cyclicReferenceObject1);
-        assertThat(mask.value(), is("CyclicReferenceObject1{intValue=1, strValue=*oo!, cyclicReferenceObject2=CyclicReferenceObject2{intValue=1, strValue=*oo!, cyclicReferenceObject1=}}"));
+
+        assertThat(mask.value(), is(expectedMaskedValue));
+    }
+
+    @Test
+    public void shouldNotLogFieldsWithIgnoreAnnotation() {
+        ClassWithIgnoreAnnotations classWithIgnoreAnnotations = new ClassWithIgnoreAnnotations();
+        String expectedMaskedValue = "ClassWithIgnoreAnnotations{str=foobar}";
+
+        Deep mask = new Deep(classWithIgnoreAnnotations);
+
+        assertThat(mask.value(), is(expectedMaskedValue));
     }
 }
 

--- a/src/test/java/com/tw/examples/appender/masks/objects/ClassWithIgnoreAnnotations.java
+++ b/src/test/java/com/tw/examples/appender/masks/objects/ClassWithIgnoreAnnotations.java
@@ -1,0 +1,19 @@
+package com.tw.examples.appender.masks.objects;
+
+import com.tw.examples.appender.masks.annotations.DeepMask;
+import com.tw.examples.appender.masks.annotations.IgnoreInLog;
+
+@DeepMask
+public class ClassWithIgnoreAnnotations {
+    @IgnoreInLog
+    private int id = 2;
+
+    @IgnoreInLog
+    SimpleWithNonPrimitiveField simpleWithNonPrimitiveField;
+
+    private String str = "foobar";
+
+    public ClassWithIgnoreAnnotations() {
+        simpleWithNonPrimitiveField = new SimpleWithNonPrimitiveField();
+    }
+}

--- a/src/test/java/com/tw/examples/appender/masks/objects/CyclicReferenceObject1.java
+++ b/src/test/java/com/tw/examples/appender/masks/objects/CyclicReferenceObject1.java
@@ -1,0 +1,16 @@
+package com.tw.examples.appender.masks.objects;
+
+import com.tw.examples.appender.masks.ShowSuffix;
+import com.tw.examples.appender.masks.annotations.DeepMask;
+import com.tw.examples.appender.masks.annotations.Masked;
+
+@DeepMask
+public class CyclicReferenceObject1
+{
+    public Integer intValue = new Integer(1);
+
+    @Masked(type = ShowSuffix.class, args="3")
+    public String strValue = "Foo!";
+
+    public CyclicReferenceObject2 cyclicReferenceObject2;
+}

--- a/src/test/java/com/tw/examples/appender/masks/objects/CyclicReferenceObject2.java
+++ b/src/test/java/com/tw/examples/appender/masks/objects/CyclicReferenceObject2.java
@@ -1,0 +1,17 @@
+package com.tw.examples.appender.masks.objects;
+
+import com.tw.examples.appender.masks.ShowSuffix;
+import com.tw.examples.appender.masks.annotations.DeepMask;
+import com.tw.examples.appender.masks.annotations.Masked;
+
+@DeepMask
+public class CyclicReferenceObject2
+{
+
+    public Integer intValue = new Integer(1);
+
+    @Masked(type = ShowSuffix.class, args="3")
+    public String strValue = "Foo!";
+
+    public CyclicReferenceObject1 cyclicReferenceObject1;
+}


### PR DESCRIPTION
I have tried to resolve the cyclic dependencies during Deep masking by storing the already masked objects in a map and checking them to see if an object has to be masked. If an object has already been masked, an empty string is returned(not sure if returning empty string is correct).
